### PR TITLE
Allow cleaning X-Forwarded-For without rewriting remote address

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -111,6 +111,11 @@ the right place, use::
 
     XFF_LOOSE_UNSAFE = True
 
+By default, this middleware rewrites ``REMOTE_ADDR``. To leave it
+untouched, use::
+
+    XFF_REWRITE_REMOTE_ADDR = False
+
 If you want to keep the ``X-Forwarded-For`` header untouched even if
 there are extra entries, use::
 

--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,7 @@ What ``django-xff`` does
 ========================
 
 This library provides a decent and configurable middleware to rewrite
-the ``request.META['HTTP_REMOTE_ADDR']`` to the correct client IP.
+the ``request.META['REMOTE_ADDR']`` to the correct client IP.
 
 This is done by setting a depth of reverse proxies to be trusted alone.
 The ``X-Forwarded-For`` header will additionally be sanitized from any

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -131,11 +131,6 @@ class TestClean(WebTestCase):
     def setUp(self):
         self.middleware = XForwardedForMiddleware()
         self.client = Client()
-        self.patcher = patch('xff.middleware.logger', autospec=True)
-        self.logger = self.patcher.start()
-
-    def tearDown(self):
-        self.patcher.stop()
 
     @override_settings(XFF_TRUSTED_PROXY_DEPTH=2)
     def test_too_many_proxies_rewrites_xff(self):
@@ -162,11 +157,6 @@ class TestRewriteRemote(WebTestCase):
     def setUp(self):
         self.middleware = XForwardedForMiddleware()
         self.client = Client()
-        self.patcher = patch('xff.middleware.logger', autospec=True)
-        self.logger = self.patcher.start()
-
-    def tearDown(self):
-        self.patcher.stop()
 
     @override_settings(XFF_TRUSTED_PROXY_DEPTH=2)
     def test_rewrites_remote_addr(self):

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -127,6 +127,37 @@ class TestStrict(WebTestCase):
         assert not self.logger.method_calls
 
 
+class TestClean(WebTestCase):
+    def setUp(self):
+        self.middleware = XForwardedForMiddleware()
+        self.client = Client()
+        self.patcher = patch('xff.middleware.logger', autospec=True)
+        self.logger = self.patcher.start()
+
+    def tearDown(self):
+        self.patcher.stop()
+
+    @override_settings(XFF_TRUSTED_PROXY_DEPTH=2)
+    def test_too_many_proxies_rewrites_xff(self):
+        response = self.client.get(
+            '/',
+            HTTP_X_FORWARDED_FOR='127.0.0.1, 127.0.0.2, 127.0.0.3')
+        self.assert_http_ok(response)
+        request = response.wsgi_request
+        self.assertEqual('127.0.0.2,127.0.0.3',
+                         request.META['HTTP_X_FORWARDED_FOR'])
+
+    @override_settings(XFF_TRUSTED_PROXY_DEPTH=2, XFF_CLEAN=False)
+    def test_can_be_disabled(self):
+        response = self.client.get(
+            '/',
+            HTTP_X_FORWARDED_FOR='127.0.0.1, 127.0.0.2, 127.0.0.3')
+        self.assert_http_ok(response)
+        request = response.wsgi_request
+        self.assertEqual('127.0.0.1, 127.0.0.2, 127.0.0.3',
+                         request.META['HTTP_X_FORWARDED_FOR'])
+
+
 class TestRewriteRemote(WebTestCase):
     def setUp(self):
         self.middleware = XForwardedForMiddleware()
@@ -159,6 +190,30 @@ class TestRewriteRemote(WebTestCase):
         self.assert_http_ok(response)
         request = response.wsgi_request
         self.assertEqual('127.0.0.9', request.META['REMOTE_ADDR'])
+
+
+class TestProxyDepth(WebTestCase):
+    def setUp(self):
+        self.middleware = XForwardedForMiddleware()
+        self.client = Client()
+        self.patcher = patch('xff.middleware.logger', autospec=True)
+        self.logger = self.patcher.start()
+
+    def tearDown(self):
+        self.patcher.stop()
+
+    @override_settings(XFF_TRUSTED_PROXY_DEPTH=2)
+    def test_too_many_proxies_logs_spoof_attempt(self):
+        response = self.client.get(
+            '/',
+            HTTP_X_FORWARDED_FOR='127.0.0.1, 127.0.0.2, 127.0.0.3')
+        self.assert_http_ok(response)
+        expected_message = (
+            'X-Forwarded-For spoof attempt with 3 addresses when 2 expected. '
+            'Full header: 127.0.0.1, 127.0.0.2, 127.0.0.3'
+        )
+        self.logger.info.assert_called_once_with(expected_message)
+
 
 
 class TestNoSpoofing(WebTestCase):


### PR DESCRIPTION
* Provide an option to not rewrite the REMOTE_ADDR. (bdda927)


* Add basic tests for the clean and proxy depth options. (a8399eb)

    This follows the same basic approach as the tests in the previous commit.

* Adjust documentation to follow what the implementation appears to do. (57571fc)

    I noticed the discrepancy when adding tests for XFF_REWRITE_REMOTE_ADDR.

---

I have a situation where I'd like to clean the X-Forwarded-For to strip out values from the untrusted client, but would like to do that without rewriting the remote address.

If you'd like the related but somewhat tangential changes broken out into separate pull requests, please let me know.